### PR TITLE
Read sample files remotely, write locally to temp file before pushing to Synapse

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -112,12 +112,12 @@ class TestScopeModification(object):
         folder_one = conftest.folder(syn, project)
         folder_two = conftest.folder(syn, project)
         folder_three = conftest.folder(syn, project)
-        file_one = conftest.file_(syn, folder_one, conftest.SAMPLE_FILE,
-                                  {'color': 'red'})
-        file_two = conftest.file_(syn, folder_two, conftest.SAMPLE_FILE,
-                                  {'pizza': 'pineapple'})
-        file_three = conftest.file_(syn, folder_three, conftest.SAMPLE_FILE,
-                                    {'cookie': 'monster'})
+        file_one = conftest.file_(syn, folder_one,
+                                  annotations={'color': 'red'})
+        file_two = conftest.file_(syn, folder_two,
+                                  annotations={'pizza': 'pineapple'})
+        file_three = conftest.file_(syn, folder_three,
+                                    annotations={'cookie': 'monster'})
         return {1: folder_one, 2: folder_two, 3: folder_three}
 
     """


### PR DESCRIPTION
Fixes #52 

Resolves the file dependency issue we've been having by reading the sample files from master branch and writing them to a temp file before pushing back to Synapse during testing.

We can change this to read from a sample project on Synapse now or later.